### PR TITLE
Removed safe area

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,23 +30,21 @@ class WelcomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: kBackgroundColor,
-      body: SafeArea(
-          child: SingleChildScrollView(
-        child: Column(
-          children: [
-            _Header(),
-            Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: _SignInForm()),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 64),
-              child: _Footer(),
-            )
-          ],
-        ),
-      )),
-    );
+        backgroundColor: kBackgroundColor,
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              _Header(),
+              Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32),
+                  child: _SignInForm()),
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 64),
+                child: _Footer(),
+              )
+            ],
+          ),
+        ));
   }
 }
 


### PR DESCRIPTION
iphone画面に合うよう修正してみました。（セーフエリアを削除）
chromeの画面には合っていたが、iphone画面ではセーフエリアが空白部分となり最下部のテキストがスクロールしないと見えなかったため。
デザイン的にはこちらの方が自然でしょうか。
<img width="410" alt="スクリーンショット 2023-07-03 22 38 08" src="https://github.com/Atsuki335/Sign-inApp/assets/115479448/5d9fbee1-633e-4796-b0f1-f2002c46fe55">
